### PR TITLE
URI parsing fix in module: Small Files

### DIFF
--- a/src/skel/usr/share/dcache/lib/hsm-internal.sh
+++ b/src/skel/usr/share/dcache/lib/hsm-internal.sh
@@ -128,7 +128,7 @@ mongoUrl=$(echo "$*"|grep -o -e '-mongoUrl=[^ $]*'|grep -o -e '[^=]*$')
 export mongoUrl
 dcapLib=$(echo "$*"|grep -o -e '-dcapLib=[^ $]*'|grep -o -e '[^=]*$')
 export dcapLib
-uri=$(echo "$*"|grep -o -e '-uri=[^ $]*'|grep -o -e '[^-][^u][^r][^i][^=].*$')
+uri=$(echo "$*"|grep -o -e '-uri *= *[^ $]*'|grep -o -e '[^-uri *= *].*$')
 export uri
 #
 ##################################################################################


### PR DESCRIPTION
Corrected URI parsing in hsm-internal.sh. The previous regexes would not
strip the URI from the command line correctly. This version is also
robust against padding space characters around the "=" sign.

Ticket:
Acked-by:
Target: trunk
Require-book: no
Require-notes: no